### PR TITLE
v0.2: observe page changes and inject the script before page load

### DIFF
--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -65,7 +65,11 @@
     }
 
     // TODO: Use toggle instead of button, and add more features to the toggle, e.g., editing tokens.
+    function EnsureCommentButton() {
         const MARK = 'comment-button'
+        if (document.querySelector(`button[${ATTR}="${MARK}"]`)) {
+            return;
+        }
         // First, find the "table-list-header-toggle" div
         var toggleDiv = document.querySelector('.table-list-header-toggle.float-right');
 

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -112,33 +112,40 @@
         });
     }
 
-    function CreateFileLink() {
+    function EnsureFileLink(issueElement) {
+        const MARK = 'file-link-span'
 
-        // Get all div elements with an id that starts with "issue_"
-        var issueElements = document.querySelectorAll('div[id^="issue_"]');
-        issueElements.forEach((element) => {
-            var issueId = element.getAttribute("id")
-            var originalLinkElement = document.getElementById(issueId + "_link")
-            var originalLink = originalLinkElement.getAttribute("href")
-            var newLink = originalLink + "/files"
-            // Get all span elements within the current element
-            var spanElements = element.querySelectorAll('span[class="opened-by"]');
-            if (spanElements.length == 1) {
-                var openedBy = spanElements[0];
-                var linkSpanElement = document.createElement('span');
-                linkSpanElement.setAttribute('class', 'd-inline-block mr-1')
-                var dotSpanElement = document.createElement('span');
-                dotSpanElement.innerHTML = ' • ';
-                dotSpanElement.setAttribute('class', 'd-inline-block mr-1')
-                var linkElement = document.createElement('a')
-                linkElement.setAttribute('href', newLink)
-                linkElement.setAttribute('class', 'Link--muted')
-                linkElement.innerHTML = "Files"
-                linkSpanElement.appendChild(linkElement)
-                openedBy.insertAdjacentElement('beforebegin', linkSpanElement)
-                openedBy.insertAdjacentElement('beforebegin', dotSpanElement);
-            }
-        })
+        if (issueElement.querySelector(`span[${ATTR}="${MARK}"]`)) {
+            return; // Already added
+        }
+
+        var issueId = issueElement.getAttribute("id")
+        var originalLinkElement = document.getElementById(issueId + "_link")
+        if (!originalLinkElement) {
+            return; // Element is not ready
+        }
+
+        var originalLink = originalLinkElement.getAttribute("href")
+        var newLink = originalLink + "/files"
+
+        var openedByElement = issueElement.querySelectorAll('span[class="opened-by"]');
+        if (openedByElement.length == 1) {
+            var openedBy = openedByElement[0];
+            var linkSpanElement = document.createElement('span');
+            linkSpanElement.setAttribute('class', 'd-inline-block mr-1 custom')
+            linkSpanElement.setAttribute(ATTR, MARK)
+            var dotSpanElement = document.createElement('span');
+            dotSpanElement.innerHTML = ' • ';
+            dotSpanElement.setAttribute('class', 'd-inline-block mr-1 custom')
+            var linkElement = document.createElement('a')
+            linkElement.setAttribute('href', newLink)
+            linkElement.setAttribute('class', 'Link--muted')
+            linkElement.innerHTML = "Files"
+            linkSpanElement.appendChild(linkElement)
+            openedBy.insertAdjacentElement('beforebegin', linkSpanElement)
+            openedBy.insertAdjacentElement('beforebegin', dotSpanElement);
+        }
+    }
 
     }
 

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -147,10 +147,18 @@
         }
     }
 
+    function Init() {
+
+        const observer = new MutationObserver(() => {
+            document.querySelectorAll('div[id^="issue_"]').forEach((element) => {
+                EnsureFileLink(element);
+            })
+            EnsureCommentButton();
+        });
+        const config = { childList: true, subtree: true };
+        observer.observe(document, config);
     }
 
-    // TODO: Do this everytime on switching to new page
-    CreateCommentButton();
-    CreateFileLink();
+    Init();
 
 })();

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -5,6 +5,7 @@
 // @author       Oreo
 // @match        https://github.com/*/pulls*
 // @grant        none
+// @run-at       document-start
 // ==/UserScript==
 
 (function () {

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -12,6 +12,7 @@
 
     'use strict';
 
+    const ATTR = 'octopus-github-util-mark'
     const STORAGEKEY = 'octopus-github-util:token'
 
     function GetRepositoryInformation() {
@@ -64,7 +65,7 @@
     }
 
     // TODO: Use toggle instead of button, and add more features to the toggle, e.g., editing tokens.
-    function CreateCommentButton() {
+        const MARK = 'comment-button'
         // First, find the "table-list-header-toggle" div
         var toggleDiv = document.querySelector('.table-list-header-toggle.float-right');
 
@@ -72,6 +73,7 @@
         var button = document.createElement('button');
         button.innerHTML = 'Comment';
         button.setAttribute('class', 'btn btn-sm js-details-target d-inline-block float-left float-none m-0 mr-md-0 js-title-edit-button')
+        button.setAttribute(ATTR, MARK)
         toggleDiv.appendChild(button);
 
         // Next, add an event listener to the button to listen for clicks

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Octopus GitHub
-// @version      0.1
+// @version      0.2
 // @description  A userscript for GitHub
 // @author       Oreo
 // @match        https://github.com/*/pulls*


### PR DESCRIPTION
- Fix #2 
- Uses `MutationObserver` to observe page changes and triggers `EnsureFileLink` and `EnsureCommentButton` functions
- Add a mark to specify elements created by this script
- Check existing elements before adding a comment button and File element
- Use `@run-at document-start` to inject the script as soon as possible 