### PR TITLE
init when dom ready

### DIFF
--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -148,13 +148,17 @@
     }
 
     function Init() {
-
-        const observer = new MutationObserver(() => {
+        // run the script when dom is ready
+        const enhanceGitHub = () => {
             document.querySelectorAll('div[id^="issue_"]').forEach((element) => {
                 EnsureFileLink(element);
             })
             EnsureCommentButton();
-        });
+        }
+
+        document.addEventListener('DOMContentLoaded', enhanceGitHub);
+
+        const observer = new MutationObserver(enhanceGitHub);
         const config = { childList: true, subtree: true };
         observer.observe(document, config);
     }


### PR DESCRIPTION
Add a listener for DOMContentLoaded. 

This makes sure that the script executes seamlessly when the DOM is fully loaded without any manual page refresh required.

> **Note:** I've tested it in my browser and it worked as expected, but please double check it on your machine. 