### PR TITLE
feat: add comment button on pr page

### DIFF
--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -6,7 +6,7 @@
 // @match        https://github.com/*/pulls*
 // @match        https://github.com/*/pull/*
 // @grant        none
-// @run-at       document-end
+// @run-at       document-start
 // ==/UserScript==
 
 (function () {
@@ -120,6 +120,10 @@
         }
         // First, find the "table-list-header-toggle" div
         var headerActions = document.querySelector(".gh-header-actions");
+        
+        if (!headerActions) {
+            return;
+        }
 
         // Next, create a button element and add it to the page
         var button = document.createElement("button");

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -287,13 +287,12 @@
         if (url.includes('/pull/')) {
             EnsureScrollToTopButton();
             EnsureScrollToBottomButton();
+            EnsureCommentButtonOnPR();
 
-            const observerCallback = () => {
+            const observer = new MutationObserver(() => {
                 EnsureCommentButtonOnPR();
-            };
-            const observer = new MutationObserver(observerCallback);
-            const targetNode = url.includes('files')
-                  ? document.body : document.querySelector(".js-issues-results");
+            });
+            const targetNode = document.body;
             const observerOptions = { childList: true, subtree: true };
             observer.observe(targetNode, observerOptions);
         }


### PR DESCRIPTION
closes https://github.com/Oreoxmt/octopus-github/issues/7

1. Add a new function `EnsureCommentButtonOnPR` that adds a comment button on PR page.

<img width="1273" alt="image" src="https://github.com/Oreoxmt/octopus-github/assets/59654584/187aeed4-7259-4357-bcb5-144122e9d4c5">
<img width="1407" alt="image" src="https://github.com/Oreoxmt/octopus-github/assets/59654584/383aabaf-1a0f-4b5d-895b-39406fbfc5ea">


2. Update `Init()` to include a MutationObserver for `EnsureCommentButtonOnPR` function.

3. Change `@run-at` to `document-end`: The script will be injected when or after the DOMContentLoaded event was dispatched. ([Documentation](https://www.tampermonkey.net/documentation.php?locale=en#meta:run_at))
    - If using `document-start`, both `EnsureCommentButtonOnPR` and `EnsureCommentButton` fails at the beginning.
    <img width="552" alt="image" src="https://github.com/Oreoxmt/octopus-github/assets/59654584/ea93275a-3c0a-43bd-9769-f10b2028272a">

