### PR TITLE
fix Uncaught TypeError and update metadata

### DIFF
--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Octopus GitHub
-// @version      0.3
+// @version      0.4
 // @description  A userscript for GitHub
 // @author       Oreo
 // @match        https://github.com/*/pulls*
@@ -74,6 +74,9 @@
         // First, find the "table-list-header-toggle" div
         var toggleDiv = document.querySelector('.table-list-header-toggle.float-right');
 
+        if (!toggleDiv) {
+            return;
+        }
         // Next, create a button element and add it to the page
         var button = document.createElement('button');
         button.innerHTML = 'Comment';

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -3,6 +3,10 @@
 // @version      0.4
 // @description  A userscript for GitHub
 // @author       Oreo
+// @homepage     https://github.com/Oreoxmt/octopus-github
+// @updateURL    https://github.com/Oreoxmt/octopus-github/raw/main/gh-util.user.js
+// @downloadURL  https://github.com/Oreoxmt/octopus-github/raw/main/gh-util.user.js
+// @supportURL   https://github.com/Oreoxmt/octopus-github
 // @match        https://github.com/*/pulls*
 // @match        https://github.com/*/pull/*
 // @grant        none


### PR DESCRIPTION
v0.3 does not adequately address the edge case where `toggleDiv` is null. This causes the `Uncaught TypeError` when the script attempts to append child elements to `toggleDiv`.

This PR:

- fixes the `Uncaught TypeError` issue by adding a conditional check
- updates the metadata of `gh-util.user.js`
- releases version 0.4


