### PR TITLE
fix: trim the trailing params in SourcePRURL

### DIFF
--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -348,7 +348,8 @@
 
             const octokit = new Octokit({ auth: EnsureToken() });
             console.log(octokit);
-            const SourcePRURL = window.location.href;
+            const currentURL = window.location.href;
+            const SourcePRURL = currentURL.match(/^https:\/\/github\.com\/.+\/pull\/\d+/)[0];
             const targetRepoOwner = "pingcap";
 
             let myRepoName, targetRepoName, translationLabel;

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -90,6 +90,7 @@
     }
 
     // This function can be used to get the PR title, description, label, base, and head information
+    // TODO: Replace the URL parameter with sourceRepoOwner, sourceRepoName, and PRNumber instead of parsing the URL repeatedly in this function
     function GetPRInfo(octokit, messageTextElement, URL) {
         return new Promise((resolve, reject) => {
             const URLParts = URL.split('/');
@@ -348,22 +349,28 @@
 
             const octokit = new Octokit({ auth: EnsureToken() });
             console.log(octokit);
-            const currentURL = window.location.href;
-            const SourcePRURL = currentURL.match(/^https:\/\/github\.com\/.+\/pull\/\d+/)[0];
-            const targetRepoOwner = "pingcap";
-
+            // TODO: Define a new function to parse the current URL and return the repo owner, repo name, PR number, etc.
+            const currentURL = window.location.pathname;
+            const currentURLSplit = currentURL.split("/");
+            const currentRepoOwner = currentURLSplit[1];
+            const currentRepoName = currentURLSplit[2];
+            const currentPRNumber = currentURLSplit[4];
+            const targetRepoOwner = "pingcap"
             let myRepoName, targetRepoName, translationLabel;
-
-            if (SourcePRURL.includes("pingcap/docs-cn/pull")) {
-                myRepoName = "docs";
-                targetRepoName = "docs";
-                translationLabel = "translation/from-docs-cn";
-            } else if (SourcePRURL.includes("pingcap/docs/pull")) {
-                targetRepoName = "docs-cn";
-                myRepoName = "docs-cn";
-                translationLabel = "translation/from-docs";
+            switch (currentRepoName) {
+                case "docs-cn":
+                    myRepoName = "docs";
+                    targetRepoName = "docs";
+                    translationLabel = "translation/from-docs-cn";
+                    break;
+                case "docs":
+                    myRepoName = "docs-cn";
+                    targetRepoName = "docs-cn";
+                    translationLabel = "translation/from-docs";
+                    break;
             }
-
+            // TODO: Only concatenate the source PR URL in UpdatePRDescription
+            const SourcePRURL = `https://github.com/${currentRepoOwner}/${currentRepoName}/pull/${currentPRNumber}`;
             //1.Get the GitHub login name of the current user
             const myRepoOwner = await GetMyGitHubID();
             //2.Get the source PR information


### PR DESCRIPTION
**Problem:** 

When you run `create translate PR` on a PR page with a complicated URL (such as `https://github.com/pingcap/docs-cn/pull/13637/files#diff-bd6f4007c98142e46e6906361bc0cabc0f45a5be07136472602de9a84156c393R24-R28`), the created translate PR will have all the trailing params in its description.

For example: 
<img width="655" alt="image" src="https://github.com/Oreoxmt/octopus-github/assets/59654584/3d44e4ef-68cd-4efb-9da8-4b660036ba16">

**Fix:**
This fix removes anything that comes after the pr number so that the source PR URL is clean.