### PR TITLE
fix translation workflow dispatch ref

### DIFF
--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Octopus GitHub
-// @version      0.92
+// @version      0.93
 // @description  A userscript for GitHub
 // @author       Oreo
 // @homepage     https://github.com/Oreoxmt/octopus-github

--- a/gh-util.user.js
+++ b/gh-util.user.js
@@ -417,7 +417,7 @@
             const workflowDispatchUrl = `https://api.github.com/repos/${workflowRepoOwner}/${workflowRepoName}/actions/workflows/${workflowFileName}/dispatches`;
 
             const requestBody = {
-                ref: baseBranch,
+                ref: "master",
                 inputs: {
                     source_pr_url: sourcePRURL,
                     target_pr_url: targetPRURL


### PR DESCRIPTION
## Summary

- Trigger the synced translation workflow from the master branch instead of the target PR base branch.

## Motivation

This fixes synced translation failures when the target branch does not contain the translation workflow. After this change, clicking **Create Synced Translation PR** always triggers the translation workflow from the master branch.

## Testing

- Not run; single-line userscript change.